### PR TITLE
Made the snap point disappear immediately upon releasing the activation key

### DIFF
--- a/addons/snappy/snappy.gd
+++ b/addons/snappy/snappy.gd
@@ -36,18 +36,22 @@ func _forward_3d_gui_input(camera, event):
 	# We need mouse events to get the cursor position
 	# This means pressing the activation key when no mouse events are being sent does nothing
 	# It's rarely noticable though
-	if event is InputEventKey and event.key_label == ACTIVATION_KEY:
-		if event.pressed and not is_active:
-			is_active = true
-		if not event.pressed and is_active:
-			is_active = false
-			origin_2d = null
-			update_overlays()
+	if event is InputEventKey:
+		if event.key_label == ACTIVATION_KEY:
+			if event.pressed and not is_active:
+				is_active = true
+				return true
+			if not event.pressed and is_active:
+				is_active = false
+				origin_2d = null
+				origin = VECTOR_INF
+				update_overlays()
+				return true
+		return false
 
 	if selected == null or not event is InputEventMouse:
 		return false
 
-	#if event is InputEventMouse:
 	var now_dragging = event.button_mask == MOUSE_BUTTON_LEFT and is_active
 	if dragging and not now_dragging and origin != VECTOR_INF:
 		undo_redo.create_action("Snap vertex")
@@ -86,10 +90,6 @@ func _forward_3d_gui_input(camera, event):
 				selected.global_position -= origin - target
 				origin = target
 			return true
-	else:
-		origin = VECTOR_INF
-		origin_2d = null
-		update_overlays()
 	return false
 
 func _on_selection_changed():


### PR DESCRIPTION
Prior to this change, releasing the activation key ('v') would deactivate the addon without any visual feedback: the yellow snap point would only disappear after moving the mouse. This PR fixes this minor issue.